### PR TITLE
initial migration of archival objects

### DIFF
--- a/archivesspace.info.yml
+++ b/archivesspace.info.yml
@@ -10,3 +10,4 @@ dependencies:
   - language
   - migrate_plus
   - migrate_run
+  - title_length

--- a/config/install/auto_entitylabel.settings.node.archival_object.yml
+++ b/config/install/auto_entitylabel.settings.node.archival_object.yml
@@ -1,4 +1,4 @@
-status: '1'
+status: '0'
 pattern: "<?php\r\n// Shouldn't have to use such a hack, but there it is...\r\n// Should probably trim the title if it gets too long so it can fit the date (if it exists).\r\nif(!$entity->get('field_as_title')->isEmpty()){\r\n  echo (string) \\Drupal::service('renderer')->render($entity->field_as_title->get(0)->view());\r\n}\r\nif(!$entity->get('field_as_title')->isEmpty() && !$entity->get('field_as_date')->isEmpty()){\r\n  echo ', ';\r\n}\r\nif(!$entity->get('field_as_date')->isEmpty()){\r\n  echo (string) \\Drupal::service('renderer')->render($entity->field_as_date->get(0)->view());\r\n}\r\n?>"
 php: 1
 escape: 0

--- a/config/install/migrate_plus.migration.as_archival_object.yml
+++ b/config/install/migrate_plus.migration.as_archival_object.yml
@@ -1,0 +1,106 @@
+uuid: 5e14a74c-580b-404c-9b58-77cea2af4369
+id: as_archival_objects
+label: ArchivesSpace Archival Objects
+migration_group: archivesspace
+migration_dependencies:
+  required:
+    - as_repositories
+    - as_resources
+
+source:
+  plugin: archivesspace
+  object_type: archival_object
+  base_uri: http://localhost:8089
+  # repository: /repositories/2
+  username: admin
+  password: admin
+  keys:
+    - uri
+
+destination:
+  plugin: entity:node
+  bundle: archival_object
+
+process:
+  published:
+    plugin: skip_on_value
+    source: published
+    method: row
+    value: true
+  type:
+    plugin: default_value
+    default_value: archival_object
+  title: display_string
+  uid:
+    plugin: default_value
+    default_value: 1
+  field_archival_record_level: level
+  field_as_date:
+    plugin: sub_process
+    source: dates
+    process:
+      label: label
+      begin: begin
+      end: end
+      date_type: date_type
+      certainty: certainty
+      expression: expression
+      calendar: calendar
+  # Extents is pulling in some from higher levels. Needs debugging.
+  field_as_extent:
+    -
+      plugin: skip_on_empty
+      source: extents
+      method: process
+    -
+      plugin: sub_process
+      process:
+        portion: portion
+        number: number
+        extent_type: extent_type
+        container_summary: container_summary
+        physical_details: physical_details
+        dimensions: dimensions
+  # Parent is a bit more complex.
+  # We need to use parent if it exists, but if not, use resource.
+  field_as_parent:
+    -
+      plugin: get
+      source:
+        - parent # The URI we want to use.
+        - resource # The backup URI.
+    -
+      # Toss out empty items.
+      plugin: callback
+      callable: array_filter
+    -
+      # Return first available
+      plugin: callback
+      callable: 'current'
+    -
+      plugin: skip_on_empty
+      method: process
+    -
+      # The URI is embedded in an array, pull it out.
+      plugin: extract
+      index:
+        - ref
+    -
+      plugin: migration_lookup
+      migration:
+        - as_archival_objects
+        - as_resources
+  field_as_ref_id: ref_id
+  field_as_resource_notes:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: notes
+      message: 'Notes field is empty'
+    -
+      plugin: archivesspace_notes # Custom process to handle single and multi-part notes
+  field_as_title: title
+  field_as_weight: position
+  field_resource_identifier: component_id
+  field_resource_resource_type: level
+  field_restrictions_bool: restrictions

--- a/config/install/migrate_plus.migration.as_resources.yml
+++ b/config/install/migrate_plus.migration.as_resources.yml
@@ -9,10 +9,10 @@ migration_dependencies:
 source:
   plugin: archivesspace
   object_type: resource
-  base_uri: http://localhost:8089/repositories
-  repository: /repositories/2
-  username: drupal
-  password: drupal
+  base_uri: http://localhost:8089
+  # repository: /repositories/2
+  username: admin
+  password: admin
   keys:
     - uri
 
@@ -81,7 +81,7 @@ process:
     -
       plugin: str_replace
       regex: true
-      search: '/--+/' # Remove any double-dashes from missing id positions
+      search: '/-+$/' # Remove any trailing dashes from missing id positions
       replace: ''
   field_resource_resource_type: level
   field_restrictions_bool: restrictions

--- a/src/Plugin/migrate/process/ArchivesSpaceNotes.php
+++ b/src/Plugin/migrate/process/ArchivesSpaceNotes.php
@@ -20,6 +20,9 @@ class ArchivesSpaceNotes extends ProcessPluginBase {
    * {@inheritdoc}
    */
   public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    if (empty($value)) {
+      throw new \Drupal\migrate\MigrateSkipProcessException();
+    }
     if (!is_array($value)) {
       throw new MigrateException(sprintf('ArchivesSpace Notes process failed for destination property (%s): input is not an array.', $destination_property));
     }
@@ -52,7 +55,7 @@ class ArchivesSpaceNotes extends ProcessPluginBase {
       ];
     }
     else {
-      return [];
+      throw new \Drupal\migrate\MigrateSkipProcessException();
     }
 
   }

--- a/src/Plugin/migrate/source/ArchivesSpaceSource.php
+++ b/src/Plugin/migrate/source/ArchivesSpaceSource.php
@@ -70,6 +70,29 @@ class ArchivesSpaceSource extends SourcePluginBase {
         ];
         break;
 
+      case 'archival_object':
+        $this->fields = [
+          'ancestors' => $this->t('Ancestors'),
+          'component_id' => $this->t('Component Unique Identifier'),
+          'dates' => $this->t('Dates'),
+          'display_string' => $this->t('Display String'),
+          'extents' => $this->t('Extents'),
+          'instances' => $this->t('Instances'),
+          'level' => $this->t('Level'),
+          'linked_agents' => $this->t('Linked Agents'),
+          'parent' => $this->t('Parent Object'),
+          'position' => $this->t('Position (weight)'),
+          'publish' => $this->t('Publish'),
+          'ref_id' => $this->t('Reference Identifier'),
+          'repository' => $this->t('Repository URI'),
+          'resource' => $this->t('Resource URI'),
+          'restrictions_apply' => $this->t('Restrictions Apply'),
+          'rights_statements' => $this->t('Rights Statements'),
+          'subjects' => $this->t('Subjects'),
+          'suppressed' => $this->t('Suppressed'),
+          'title' => $this->t('Title'),
+          'uri' => $this->t('URI'),
+        ];
       default:
         break;
     }


### PR DESCRIPTION
Extents are still quirky. Some incorrectly inherit extents from parents and I don't know why yet. Needs debugging.

Also includes title_long (because some titles are really long...) and disables auto_entitylabel for archival objects because the attempted PHP solution was throwing errors.

Uses default login for initial ArchivesSpace installations.